### PR TITLE
fix wrong `Website` key's value in `plugin.json`

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -6,7 +6,7 @@
   "Author": "Garulf",
   "Version": "2.0.0",
   "Language": "python",
-  "Website": "https://github.com/Garulf/epic_games_store_launcher",
+  "Website": "https://github.com/Garulf/Epic-Games-Store-Launcher",
   "IcoPath": "./icon.png",
   "ExecuteFileName": "run.py"
 }


### PR DESCRIPTION
The `Website` key in the `plugin.json` file points to a repository that doesn't exist. Seems like the repository was renamed since it was last updated